### PR TITLE
Module Member Update

### DIFF
--- a/components/module-member/src/main/java/org/devgraft/member/api/MemberApi.java
+++ b/components/module-member/src/main/java/org/devgraft/member/api/MemberApi.java
@@ -45,6 +45,5 @@ public class MemberApi {
     @PatchMapping("{id}")
     public void updateMember(@PathVariable(name = "id") String id, @RequestBody MemberModifyRequest request) {
         memberService.modifyMember(id, request);
-
     }
 }

--- a/components/module-member/src/main/java/org/devgraft/member/domain/GenderEnum.java
+++ b/components/module-member/src/main/java/org/devgraft/member/domain/GenderEnum.java
@@ -1,0 +1,5 @@
+package org.devgraft.member.domain;
+
+public enum GenderEnum {
+    Female, Male
+}

--- a/components/module-member/src/main/java/org/devgraft/member/domain/Member.java
+++ b/components/module-member/src/main/java/org/devgraft/member/domain/Member.java
@@ -9,6 +9,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.Id;
 import java.time.LocalDateTime;
 
@@ -21,14 +23,15 @@ public class Member {
     private String id;
     private String nickName;
     private String password;
-    private int gender;
+    @Enumerated(EnumType.ORDINAL)
+    private GenderEnum gender;
     @CreatedDate
     private LocalDateTime createAt;
     @LastModifiedDate
     private LocalDateTime updateAt;
 
     @Builder
-    public Member(String id, String nickName, String password, int gender, LocalDateTime createAt, LocalDateTime updateAt) {
+    public Member(String id, String nickName, String password, GenderEnum gender, LocalDateTime createAt, LocalDateTime updateAt) {
         this.id = id;
         this.nickName = nickName;
         this.password = password;
@@ -37,7 +40,7 @@ public class Member {
         this.updateAt = updateAt;
     }
 
-    public static Member create(String id, String password, String nickName, int gender) {
+    public static Member create(String id, String password, String nickName, GenderEnum gender) {
         return Member.builder()
                 .nickName(nickName)
                 .id(id)

--- a/components/module-member/src/main/java/org/devgraft/member/service/MemberGetResponse.java
+++ b/components/module-member/src/main/java/org/devgraft/member/service/MemberGetResponse.java
@@ -3,6 +3,7 @@ package org.devgraft.member.service;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.devgraft.member.domain.GenderEnum;
 
 import java.time.LocalDateTime;
 
@@ -11,7 +12,7 @@ import java.time.LocalDateTime;
 public class MemberGetResponse {
     private final String id;
     private final String nickName;
-    private final int gender;
+    private final GenderEnum gender;
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime createAt;
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")

--- a/components/module-member/src/main/java/org/devgraft/member/service/MemberJoinRequest.java
+++ b/components/module-member/src/main/java/org/devgraft/member/service/MemberJoinRequest.java
@@ -3,7 +3,11 @@ package org.devgraft.member.service;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.devgraft.member.domain.GenderEnum;
 
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
 /**
@@ -28,5 +32,6 @@ public class MemberJoinRequest {
     private String id;
     @Pattern(regexp = "^(?=^.{8,20}$)(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*+=.,\\\\\\-<>/;:'~₩]).*$")
     private String password;
-    private int gender;
+    @Enumerated(EnumType.STRING)
+    private GenderEnum gender;
 }

--- a/components/module-member/src/main/java/org/devgraft/member/service/MemberJoinResponse.java
+++ b/components/module-member/src/main/java/org/devgraft/member/service/MemberJoinResponse.java
@@ -3,6 +3,7 @@ package org.devgraft.member.service;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.devgraft.member.domain.GenderEnum;
 
 import java.time.LocalDateTime;
 
@@ -12,7 +13,7 @@ import java.time.LocalDateTime;
 public class MemberJoinResponse {
     private final String nickName;
     private final String id;
-    private final int gender;
+    private final GenderEnum gender;
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime createAt;
 }

--- a/components/module-member/src/main/java/org/devgraft/member/service/MemberModifyRequest.java
+++ b/components/module-member/src/main/java/org/devgraft/member/service/MemberModifyRequest.java
@@ -4,9 +4,12 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.Pattern;
+
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
 public class MemberModifyRequest {
+    @Pattern(regexp = "^(?=^.{2,8}$)(?=.*[a-zA-Z가-힣0-9]).*$")
     private String nickName;
 }

--- a/components/module-member/src/test/java/org/devgraft/member/MemberFixture.java
+++ b/components/module-member/src/test/java/org/devgraft/member/MemberFixture.java
@@ -1,5 +1,6 @@
 package org.devgraft.member;
 
+import org.devgraft.member.domain.GenderEnum;
 import org.devgraft.member.domain.Member;
 
 import java.time.LocalDateTime;
@@ -9,7 +10,7 @@ public class MemberFixture {
         return Member.builder()
                 .id("id")
                 .nickName("nickName")
-                .gender(0)
+                .gender(GenderEnum.Female)
                 .password("password")
                 .createAt(LocalDateTime.now())
                 .updateAt(LocalDateTime.now());

--- a/components/module-member/src/test/java/org/devgraft/member/api/MemberApiTest.java
+++ b/components/module-member/src/test/java/org/devgraft/member/api/MemberApiTest.java
@@ -1,6 +1,7 @@
 package org.devgraft.member.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.devgraft.member.domain.GenderEnum;
 import org.devgraft.member.service.MemberGetResponse;
 import org.devgraft.member.service.MemberJoinRequest;
 import org.devgraft.member.service.SpyMemberService;
@@ -46,7 +47,7 @@ class MemberApiTest {
         String givenNickName = "nickName";
         String givenId = "id";
         String givenPassword = "password";
-        int givenGender = 0;
+        GenderEnum givenGender = GenderEnum.Female;
         MemberJoinRequest givenMemberJoinRequest = new MemberJoinRequest(givenNickName, givenId, givenPassword, givenGender);
 
         mockMvc.perform(post("/members")
@@ -54,7 +55,7 @@ class MemberApiTest {
                         .content(objectMapper.writeValueAsString(givenMemberJoinRequest)))
                 .andExpect(jsonPath("$.nickName", equalTo(givenNickName)))
                 .andExpect(jsonPath("$.id", equalTo(givenId)))
-                .andExpect(jsonPath("$.gender", equalTo(givenGender)))
+                .andExpect(jsonPath("$.gender", equalTo(givenGender.name())))
                 .andExpect(jsonPath("$.createAt", equalTo("2022-03-25 09:32:00")));
     }
 
@@ -63,7 +64,8 @@ class MemberApiTest {
         String givenNickName = "nickName2";
         String givenId = "id";
         String givenPassword = "password";
-        int givenGender = 0;
+        GenderEnum givenGender = GenderEnum.Female;
+
         MemberJoinRequest givenMemberJoinRequest = new MemberJoinRequest(givenNickName, givenId, givenPassword, givenGender);
 
         mockMvc.perform(post("/members")
@@ -87,7 +89,8 @@ class MemberApiTest {
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
         String givenId = "id12";
         String givenNickName = "nickNameaaaa";
-        int givenGender = 0;
+        GenderEnum givenGender = GenderEnum.Female;
+
         LocalDateTime givenCreateAt = LocalDateTime.of(2022, 3, 25, 22, 22, 22);
         LocalDateTime givenUpdateAt = LocalDateTime.of(2023, 2, 2, 22, 22, 22);
         spyMemberService.getMember_returnValue = new MemberGetResponse(givenId, givenNickName, givenGender, givenCreateAt, givenUpdateAt);
@@ -95,7 +98,7 @@ class MemberApiTest {
         mockMvc.perform(get("/members/{id}", givenId))
                 .andExpect(jsonPath("$.id", equalTo(givenId)))
                 .andExpect(jsonPath("$.nickName", equalTo(givenNickName)))
-                .andExpect(jsonPath("$.gender", equalTo(givenGender)))
+                .andExpect(jsonPath("$.gender", equalTo(givenGender.name())))
                 .andExpect(jsonPath("$.createAt", equalTo(givenCreateAt.format(dateTimeFormatter))))
                 .andExpect(jsonPath("$.updateAt", equalTo(givenUpdateAt.format(dateTimeFormatter))));
     }


### PR DESCRIPTION
gender 속성 타입 변경
 - int -> GenderEnum (Female, Male)
 
Member Api 변경
- searchMember gender 속성 반환 값 변경
- joinMember gender 속성 반환 값 변경
- updateMember RequestBody에서 받던 id를 PathVariable로 이동

MemberService 변경
- modifyMember 인자 값 변경 (request) -> (id:String, request:MemberModifyRequest)
- modifyMember 비즈니스 로직 작성 완료